### PR TITLE
Fix memory leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,6 @@ zig-out/bin/pure path/to/libzip/regress/*.zip
 
 ## TODOs
 
-- Nested zip files are recursively analysed to detect zip bombs, and the code
-  will allocate memory for if they are compressed. The original code would clean
-  up this memory and did not leak, but my rewrite did. I'm working around this
-  by using an arena allocator.
 - The original code would read the Zip structures by manually reading
   little-endian integers and incrementing an offset into the file. I was
   part-way through a refactor that would read packed structs, so that I could

--- a/build.zig
+++ b/build.zig
@@ -13,7 +13,7 @@ pub fn build(b: *std.build.Builder) void {
         .optimize = optimize,
     });
     pure_c.force_pic = true;
-    pure_c.addCSourceFiles(&.{"c-impl/pure.c"}, &.{"-std=c89"});
+    pure_c.addCSourceFile(.{ .file = .{ .path = "c-impl/pure.c" }, .flags = &[_][]const u8{"-std=c89"} });
     pure_c.linkLibrary(libz);
     b.installArtifact(pure_c);
 

--- a/build.zig
+++ b/build.zig
@@ -4,19 +4,6 @@ pub fn build(b: *std.build.Builder) void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{});
 
-    const zlib = b.dependency("zlib", .{ .target = target, .optimize = optimize });
-    const libz = zlib.artifact("z");
-
-    const pure_c = b.addStaticLibrary(.{
-        .name = "purec",
-        .target = target,
-        .optimize = optimize,
-    });
-    pure_c.force_pic = true;
-    pure_c.addCSourceFile(.{ .file = .{ .path = "c-impl/pure.c" }, .flags = &[_][]const u8{"-std=c89"} });
-    pure_c.linkLibrary(libz);
-    b.installArtifact(pure_c);
-
     const pure = b.addStaticLibrary(.{
         .name = "pure",
         .root_source_file = .{ .path = "src/pure.zig" },
@@ -35,21 +22,38 @@ pub fn build(b: *std.build.Builder) void {
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_unit_tests.step);
 
-    const exe = b.addExecutable(.{
-        .name = "pure",
-        .root_source_file = .{ .path = "src/cli.zig" },
+    const zlib = b.dependency("zlib", .{ .target = target, .optimize = optimize });
+    const libz = zlib.artifact("z");
+
+    const pure_c = b.addStaticLibrary(.{
+        .name = "purec",
         .target = target,
         .optimize = optimize,
     });
-    exe.linkLibrary(libz);
-    exe.linkLibrary(pure_c);
-    b.installArtifact(exe);
+    pure_c.force_pic = true;
+    pure_c.addCSourceFile(.{ .file = .{ .path = "c-impl/pure.c" }, .flags = &[_][]const u8{"-std=c89"} });
+    pure_c.linkLibrary(libz);
+    b.installArtifact(pure_c);
 
-    const run_cmd = b.addRunArtifact(exe);
+    const regress_exe = b.addExecutable(.{
+        .name = "pure",
+        .root_source_file = .{ .path = "src/regress.zig" },
+        .target = target,
+        .optimize = optimize,
+    });
+    var libzip = b.dependency("libzip", .{});
+    var regress_opts = b.addOptions();
+    regress_opts.addOptionPath("regression_zip_dir", libzip.path("regress"));
+    regress_exe.linkLibrary(libz);
+    regress_exe.linkLibrary(pure_c);
+    regress_exe.addOptions("regress", regress_opts);
+    b.installArtifact(regress_exe);
+
+    const run_cmd = b.addRunArtifact(regress_exe);
     run_cmd.step.dependOn(b.getInstallStep());
     if (b.args) |args|
         run_cmd.addArgs(args);
 
-    const run_step = b.step("run", "Run the purity test");
-    run_step.dependOn(&run_cmd.step);
+    const regress_step = b.step("regress", "Run the regression test against C version");
+    regress_step.dependOn(&run_cmd.step);
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,7 +4,8 @@
     .dependencies = .{
         .zlib = .{
             .url = "git+https://github.com/mitchellh/zig-build-zlib#830761587bf91616d45e6a2669359e7eb5d27ae7",
-	    .hash = "12201c84e11aae4391e032f2ed86862d7ee2259a0b4892ee76b2e361d06e8da37338",
+	        .hash = "12201c84e11aae4391e032f2ed86862d7ee2259a0b4892ee76b2e361d06e8da37338",
         },
     },
+    .paths = .{""},
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,10 +2,16 @@
     .name = "pure",
     .version = "1.0.5",
     .dependencies = .{
+        // Used for regression testing against C version of pure
         .zlib = .{
             .url = "git+https://github.com/MFAshby/zig-build-zlib#f7f6262574fbfffd0202b4ad881a0cec1c7c189b",
 	        .hash = "1220a81facdcb6cb3676ac1189c35477540854d31c17d63cf3bdc8b94452f781d286",
         },
+        // Used for regression testing, it has a folder of interestingly malformed ZIP files.
+        .libzip = .{
+            .url = "https://github.com/nih-at/libzip/releases/download/v1.10.1/libzip-1.10.1.tar.gz",
+            .hash = "1220be3870d531f0b2560f2de80593cf6d6950f97da940d90b0e4ed8c7e7f112dbaa",
+        }
     },
     .paths = .{""},
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "1.0.5",
     .dependencies = .{
         .zlib = .{
-            .url = "git+https://github.com/mitchellh/zig-build-zlib#830761587bf91616d45e6a2669359e7eb5d27ae7",
-	        .hash = "12201c84e11aae4391e032f2ed86862d7ee2259a0b4892ee76b2e361d06e8da37338",
+            .url = "git+https://github.com/MFAshby/zig-build-zlib#f7f6262574fbfffd0202b4ad881a0cec1c7c189b",
+	        .hash = "1220a81facdcb6cb3676ac1189c35477540854d31c17d63cf3bdc8b94452f781d286",
         },
     },
     .paths = .{""},

--- a/src/regress.zig
+++ b/src/regress.zig
@@ -1,5 +1,46 @@
 const std = @import("std");
 const pure = @import("pure.zig");
+const regress = @import("regress");
+
+// Runs a regression test of C version of pure against Zig version
+// Using libzip regression testing set.
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{
+        // .enable_memory_limit = true,
+        // .never_unmap = true,
+        // .retain_metadata = true,
+    }){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    var dir = try std.fs.openIterableDirAbsolute(regress.regression_zip_dir, .{});
+    var walker = try dir.walk(allocator);
+    defer walker.deinit();
+    var count: usize = 0;
+    while (try walker.next()) |entry| {
+        if (std.mem.endsWith(u8, entry.basename, ".zip")) {
+            var zip = try open_mmap(entry.dir, entry.path);
+            defer std.os.munmap(zip);
+            var ret_zig: convertedErrors = error.ok;
+            pure.zip(zip, allocator) catch |err| {
+                ret_zig = err;
+            };
+            const ret_c = pure_zip(zip.ptr, zip.len, 0);
+            if (ret_zig != convertError(ret_c))
+                std.log.err("{s}: {} instead of {}\n", .{ entry.path, ret_zig, ret_c });
+            count += 1;
+        }
+    }
+    std.log.info("checked {} zips", .{count});
+}
+
+// Result must be closed with std.os.munmap
+fn open_mmap(dir: std.fs.Dir, file_path: []const u8) ![]align(std.mem.page_size) u8 {
+    var f = try dir.openFile(file_path, .{ .mode = .read_only });
+    defer f.close();
+    const stat = try f.stat();
+    return try std.os.mmap(null, stat.size, std.os.PROT.READ, std.os.MAP.PRIVATE, f.handle, 0);
+}
 
 pub const E = enum(c_int) {
     OK,
@@ -344,52 +385,3 @@ fn convertError(e: E) convertedErrors {
 }
 
 pub extern fn pure_zip(buffer: [*c]const u8, size: u64, flags: u64) E;
-
-pub fn main() !void {
-    var buf_out = std.io.bufferedWriter(std.io.getStdOut().writer());
-    const writer = buf_out.writer();
-    var gpa = std.heap.GeneralPurposeAllocator(.{
-        // .retain_metadata = true,
-        // .verbose_log = true,
-    }){};
-    defer _ = gpa.deinit();
-    const allocator = gpa.allocator();
-
-    var arg_iterator = try std.process.argsWithAllocator(allocator);
-    defer arg_iterator.deinit();
-    std.debug.assert(arg_iterator.skip()); // program name
-    var next_arg: ?[]const u8 = arg_iterator.next() orelse return error.NoArgs;
-    var check_error = false;
-    if (std.mem.eql(u8, next_arg.?, "-c")) {
-        check_error = true;
-        next_arg = arg_iterator.next() orelse return error.NoArgs;
-    }
-
-    while (next_arg) |arg| : (next_arg = arg_iterator.next()) {
-        var zip = try open_mmap(arg);
-        defer std.os.munmap(zip);
-
-        var ret_zig: convertedErrors = error.ok;
-        pure.zip(zip, allocator) catch |err| {
-            ret_zig = err;
-        };
-
-        if (check_error) {
-            const ret_c = pure_zip(zip.ptr, zip.len, 0);
-            if (ret_zig != convertError(ret_c))
-                try writer.print("{s}: {} instead of {}\n", .{ arg, ret_zig, ret_c });
-        } else {
-            try writer.print("{s} - {}\n", .{ arg, ret_zig });
-        }
-    }
-
-    try buf_out.flush();
-}
-
-// Result must be closed with std.os.munmap
-fn open_mmap(file_path: []const u8) ![]align(std.mem.page_size) u8 {
-    var f = try std.fs.cwd().openFile(file_path, .{ .mode = .read_only });
-    defer f.close();
-    const stat = try f.stat();
-    return try std.os.mmap(null, stat.size, std.os.PROT.READ, std.os.MAP.PRIVATE, f.handle, 0);
-}


### PR DESCRIPTION
Also fix the build for latest zig master. Note I have raised a [separate PR](https://github.com/mitchellh/zig-build-zlib/pull/2) for fixing up zig-build-zlib which this project depends on,so the dependency specified in build.zig.zon should be changed back again if that gets merged. 

Memory leak is fixed, run against the libzip regression suite with -c option and it runs clean:
```
martin@martin-pinebook ~/d/pure (zig-port)> zig build run -- -c ~/dev/libzip/regress/*.zip
martin@martin-pinebook ~/d/pure (zig-port)>
```

This is a completely unsolicited pull request so feel free to close it if you're not accepting PRs right now :D